### PR TITLE
Don't put empty version string in message header

### DIFF
--- a/Kernel/Constants.cs
+++ b/Kernel/Constants.cs
@@ -6,6 +6,6 @@ namespace iCSharp.Kernel
     {
         public const string USERNAME = "icsharp_kernel";
 
-        public const string VERSION = "";
+        public const string VERSION = "4.0";
     }
 }

--- a/Kernel/MessageBuilder.cs
+++ b/Kernel/MessageBuilder.cs
@@ -14,8 +14,7 @@ namespace iCSharp.Kernel
                 Username = Constants.USERNAME,
                 Session = session,
                 MessageId = Guid.NewGuid().ToString(),
-                MessageType = messageType,
-                Version = Constants.VERSION
+                MessageType = messageType
             };
 
             return newHeader;


### PR DESCRIPTION
- implemented protocol version is 4.0
- msgspec v4 doesn't include version in the header
- empty version string is never valid on any version

Providing an empty version string is causing adaptation to fail (jupyter/jupyter_client#70), but it is never valid to provide an empty version string.

Might be enough to close #5