### PR TITLE
Bring ICSharp up to date: refresh the installation instructions and upgrade scriptcs to fix failing NuGet restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 [![Build Status](https://travis-ci.org/zabirauf/icsharp.svg)](https://travis-ci.org/zabirauf/icsharp)
 
 #Interactive C# Notebook
-ICSharp is an C# language kernel for [IPython.](http://ipython.org) It allows users
-to use IPython's Notebook frontend, except where IPython executes python code, ICSharp
+ICSharp is an C# language kernel for [Jupyter.](http://jupyter.org) It allows users
+to use Jupyter's Notebook frontend, except where Jupyter executes python code, ICSharp
 can execute C# code. It is based on Roslyn REPL engine of [scriptcs.](http://scriptcs.net/),
 so all the goodies of scriptcs comes along with it.
 
-This is on top of all of IPython's other frontend features like Markdown rendering,
+This is on top of all of Jupyter's other frontend features like Markdown rendering,
 HTML rendering, saving notebooks for later use and even the ability to view ICSharp
-Notebooks in [IPython's NBViewer](http://nbviewer.ipython.org/)
+Notebooks in [Jupyter's NBViewer](http://nbviewer.jupyter.org/).
 
 ###Disclaimer
 The development of this language kernel for C# is at it's very early stages.
@@ -18,25 +18,19 @@ This is Alpha. Take with a large pinch of salt :)
 
 #### [Mac OS X](https://github.com/zabirauf/icsharp/wiki/Install-on-Mac-OS-X)
 
-#### [Linux] (https://github.com/zabirauf/icsharp/wiki/Install-on-Unix-(Debian-7.8))
+#### [Linux](https://github.com/zabirauf/icsharp/wiki/Install-on-Unix-(Debian-7.8))
 
-#### Windows
-
-1. Install [chocolatey](https://chocolatey.org)
-2. Install [python \(2.x\)](https://chocolatey.org/packages/python2) and [pip](https://chocolatey.org/packages/pip) using chocolatey
-3. Install [ipython](http://ipython.org/install.html) using pip
-4. Install [ICSharp](https://chocolatey.org/packages/ICSharp/0.1) using chocolatey by executing `choco install ICSharp`
-5. Start IPython notebook with C# kernel by running `ipython notebook --profile=icsharp`
+#### [Windows](https://github.com/zabirauf/icsharp/wiki/Installation)
 
 ###Feedback
 I am eager to receive [feedback](mailto:zabirauf@gmail.com) from anyone who has attempted to use ICSharp. I would love to hear
 some thoughts on how to improve ICSharp.
 
 ###Known Issues
-* Console.WriteLine does not print output in the notebook
-* Console.ReadLine does not work currently
+* `Console.WriteLine` does not print output in the notebook
+* `Console.ReadLine` does not work currently
 
-##[Demo](http://nbviewer.ipython.org/urls/gist.githubusercontent.com/zabirauf/a0d4aa22b383afaa1e23/raw/65e539dc98b2cf3e38cc26faf3575e50f4ac9108/iCSharp%20Sample.ipynb)
+##[Demo](http://nbviewer.jupyter.org/urls/gist.githubusercontent.com/zabirauf/a0d4aa22b383afaa1e23/raw/65e539dc98b2cf3e38cc26faf3575e50f4ac9108/iCSharp%20Sample.ipynb)
 
 ## Contributors
 Thanks to contributors (in alphabetic order).


### PR DESCRIPTION
This PR includes two changes that bring ICSharp up to date. I had a hard time figuring out on my own how to build and use it since (a) all the instructions were outdated in different ways, and (b) the scriptcs dependency was broken.

### 1. Update scriptcs to its current `master`.
Most importantly, this fixes [scriptcs#1171](https://github.com/scriptcs/scriptcs/issues/1171) by upgrading `Nuget.Core` to 2.14.0. I encountered the same error with multiple packages when I tried to use ICSharp with an outdated csriptcs dependency.

### 2. Refresh the installation instructions.
I updated the [Windows installation page](https://github.com/zabirauf/icsharp/wiki/Installation) in the wiki and put a link there to `README.md`. The original instructions (with pip and chocolatey) are outdated. On that note, can we push a new pip/chocolatey package release?

**P.S.** The Travis build fails consistently, even in `master`. I don't have time to take a look at it right now, but some unit tests definitely need updates as well.